### PR TITLE
API Update  0.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ dist: xenial
 language: python
 python:
   - "3.5"
+  - "3.6"
+  - "3.7"
 env:
   matrix:
   - TOXENV=py3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 
 
 
+## Unreleased - 2018-12-21
+
+### Changed
+- **login** become a static method of YAKS and creates the YAKS API ( YAKS.login() returns a **YAKS** object)
+- _put_; _update_; _remove_; _eval_; _workspace_ takes **Path** or **str**
+- _get_; _subscribe_ takes **Selector** or  **str**
+- _get_; _subscribe_ and _eval_; returns **str** as default for _paths_ the optional parameter _paths_as_string=False allow enable returns of YAKS types 
+- storage creation takes an id and a dictionary of properties with at least the property _is.yaks.storage.selector_ set with a valid **Selector**  or **str**
+
 ## [0.1.0] - 2018-12-20
 ### Added
 - **Value** class for values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,14 @@ All notable changes to this project will be documented in this file.
 
 
 
-## Unreleased - 2018-12-21
+## [0.1.1] - 2018-12-21
 
 ### Changed
 - **login** become a static method of YAKS and creates the YAKS API ( YAKS.login() returns a **YAKS** object)
-- _put_; _update_; _remove_; _eval_; _workspace_ takes **Path** or **str**
-- _get_; _subscribe_ takes **Selector** or  **str**
+- _put_; _update_; _remove_; _eval_; _workspace_ takes **str** or **Path** 
+- _get_; _subscribe_ takes  **str** or **Selector**
 - _get_; _subscribe_ and _eval_; returns **str** as default for _paths_ the optional parameter _paths_as_string=False allow enable returns of YAKS types 
-- storage creation takes an id and a dictionary of properties with at least the property _is.yaks.storage.selector_ set with a valid **Selector**  or **str**
+- storage creation takes an id and a dictionary of properties with at least the property _is.yaks.storage.selector_ set with a valid **str**  or **Selector**
 
 ## [0.1.0] - 2018-12-20
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ This repo contains the YAKS API binding for Python
 
 #### Installation
 
-    python3 setup.py install
+    $ python3 setup.py install
+
+or
+
+    $ pip3 install yaks
 
 #### Changelog 
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repo contains the YAKS API binding for Python
 
 #### Changelog 
 
-See [changelog file](CHANGELOG.md))
+See [changelog file](CHANGELOG.md)
 
 #### Examples
 

--- a/examples/client-sql.py
+++ b/examples/client-sql.py
@@ -14,8 +14,7 @@ import sys
 
 def main():
     print('creating api')
-    y = YAKS()
-    y.login(sys.argv[1])
+    y = YAKS.login(sys.argv[1])
 
     print('>> Create memory storage')
     input()

--- a/examples/client.py
+++ b/examples/client.py
@@ -17,8 +17,7 @@ def evcb(path, param):
 
 def main():
     print('creating api')
-    y = YAKS()
-    y.login(sys.argv[1])
+    y = YAKS.login(sys.argv[1])
     print('>> Create storage')
     input()
     myst_id = 100
@@ -29,7 +28,8 @@ def main():
     input()
     workspace = y.workspace(Path('/myyaks'))
 
-    sid = workspace.subscribe(Selector('/myyaks/example/**'), obs)
+    sid = workspace.subscribe(Selector('/myyaks/example/**'), obs,
+                              paths_as_strings=False)
 
     print('>> Put Tuple')
     input()
@@ -50,23 +50,27 @@ def main():
 
     print('>> Get Tuple')
     input()
-    print('GET: {}'.format(workspace.get(Selector('/myyaks/example/one'))))
+    print('GET: {}'.format(workspace.get(
+        Selector('/myyaks/example/one'), paths_as_strings=False)))
 
     print('>> Get Tuple')
     input()
-    print('GET: {}'.format(workspace.get(Selector('/myyaks/example'))))
+    print('GET: {}'.format(workspace.get(
+        Selector('/myyaks/example'), paths_as_strings=False)))
 
     print('>> Get Tuple')
     input()
-    print('GET: {}'.format(workspace.get(Selector('/myyaks/example/*'))))
+    print('GET: {}'.format(workspace.get(
+        Selector('/myyaks/example/*'), paths_as_strings=False)))
 
     print('>> Put Eval')
     input()
-    workspace.eval(Path('/myyaks/key1'), evcb)
+    workspace.eval(Path('/myyaks/key1'), evcb, paths_as_strings=False)
 
     print('>> Get on Eval')
     input()
-    print('GET: {}'.format(workspace.get(Selector('/myyaks/key1?[param=1]'))))
+    print('GET: {}'.format(workspace.get(
+        Selector('/myyaks/key1?[param=1]'), paths_as_strings=False)))
 
     print('>> Dispose Access')
     input()

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def read(fname):
 
 setup(
     name='yaks',
-    version='0.1.0',
+    version='0.1.1',
     author='ADLINK Advance Technology Office',
     description='Python API to access the YAKS service',
     long_description=read('README.md'),

--- a/yaks/logger.py
+++ b/yaks/logger.py
@@ -42,8 +42,13 @@ class APILogger:
             self.logger.setLevel(log_level)
             formatter = logging.Formatter(log_format)
             if not debug_flag:
-                #log_filename = self.log_file
-                handler = logging.handlers.SysLogHandler()
+                platform = sys.platform
+                if platform == 'linux':
+                    handler = logging.handlers.SysLogHandler('/dev/log')
+                elif platform == 'darwin':
+                    handler = logging.handlers.SysLogHandler('/var/run/syslog')
+                elif platform in ['windows', 'Windows', 'win32']:
+                    handler = logging.handlers.SysLogHandler()
             else:
                 handler = logging.StreamHandler(sys.stdout)
             handler.setFormatter(formatter)

--- a/yaks/messages.py
+++ b/yaks/messages.py
@@ -495,7 +495,6 @@ class MessageDelete(Message):
             self.add_property('is.yaks.access.id', id)
         elif dtype is EntityType.STORAGE:
             self.set_s()
-            print('>> Storage Id: {}'.format(id))
             self.add_property('is.yaks.storage.id', id)
         elif path is not None:
             self.add_property('is.yaks.access.id', id)

--- a/yaks/selector.py
+++ b/yaks/selector.py
@@ -65,7 +65,6 @@ class Selector(object):
         if self.properties is None:
             return data
         uri_values = self.properties.split(';')
-        #print (uri_values)
         for tokens in uri_values:
             v = tokens.split('=')[-1]
             k = tokens.split('=')[0]

--- a/yaks/tests/test_api.py
+++ b/yaks/tests/test_api.py
@@ -27,59 +27,84 @@ import time
 class APITest(unittest.TestCase):
 
     def test_create_close_api(self):
-        y = YAKS()
-        self.assertFalse(y.is_connected)
-        y.login(server_address='127.0.0.1')
+        #y = YAKS()
+        #self.assertFalse(y.is_connected)
+        y = YAKS.login(server_address='127.0.0.1')
         self.assertTrue(y.is_connected)
         y.logout()
         self.assertFalse(y.is_connected)
 
     def test_create_delete_storage(self):
-        y = YAKS()
-        y.login(server_address='127.0.0.1')
+        y = YAKS.login(server_address='127.0.0.1')
+        properties = {'is.yaks.storage.selector': Selector('/myyaks')}
+        sid = y.create_storage('123', properties)
+        self.assertEqual(sid, '123')
+        y.remove_storage(sid)
+        y.logout()
+
+    def test_create_delete_storage_non_str_id(self):
+        y = YAKS.login(server_address='127.0.0.1')
         properties = {'is.yaks.storage.selector': Selector('/myyaks')}
         sid = y.create_storage(123, properties)
-        self.assertEqual(sid, 123)
+        self.assertEqual(sid, '123')
         y.remove_storage(sid)
         y.logout()
 
     def test_create_delete_workspace(self):
-        y = YAKS()
-        y.login(server_address='127.0.0.1')
+        y = YAKS.login(server_address='127.0.0.1')
         properties = {'is.yaks.storage.selector': Selector('/myyaks')}
-        sid = y.create_storage(123, properties)
+        sid = y.create_storage('123', properties)
         workspace = y.workspace(Path('/myyaks'))
-        self.assertEqual(sid, 123)
+        self.assertEqual(sid, '123')
         self.assertEqual(workspace.path, Path('/myyaks'))
         workspace.dispose()
         y.remove_storage(sid)
         y.logout()
 
     def test_put_get_remove(self):
-        y = YAKS()
-        y.login(server_address='127.0.0.1')
+        y = YAKS.login(server_address='127.0.0.1')
         properties = {'is.yaks.storage.selector': Selector('/myyaks')}
-        sid = y.create_storage(123, properties)
+        sid = y.create_storage('123', properties)
         workspace = y.workspace(Path('/myyaks'))
         d = Value(json.dumps({'value': 1}))
         self.assertTrue(workspace.put(Path('/myyaks/key1'), d))
-        nd = workspace.get(Selector('/myyaks/key1'))[0]
+        nd = workspace.get(Selector('/myyaks/key1'), paths_as_strings=False)[0]
         k = nd.get('key')
         v = nd.get('value')
         self.assertEqual(v, d)
         self.assertEqual(k, Path('/myyaks/key1'))
         d = Value(json.dumps({'value': 2}))
         self.assertTrue(workspace.remove(Path('/myyaks/key1')))
-        self.assertEqual(workspace.get(Path('/myyaks/key1')), [])
+        self.assertEqual(workspace.get(Selector('/myyaks/key1'),
+                                       paths_as_strings=False), [])
+        workspace.dispose()
+        y.remove_storage(sid)
+        y.logout()
+
+    def test_put_get_remove_strings(self):
+        y = YAKS.login(server_address='127.0.0.1')
+        properties = {'is.yaks.storage.selector': '/myyaks'}
+        sid = y.create_storage('123', properties)
+        workspace = y.workspace('/myyaks')
+        d = Value(json.dumps({'value': 1}))
+        self.assertTrue(workspace.put('/myyaks/key1', d))
+        nd = workspace.get('/myyaks/key1')[0]
+        k = nd.get('key')
+        v = nd.get('value')
+        self.assertEqual(v, d)
+        self.assertEqual(k, '/myyaks/key1')
+        d = Value(json.dumps({'value': 2}))
+        self.assertTrue(workspace.remove('/myyaks/key1'))
+        self.assertEqual(workspace.get('/myyaks/key1'), [])
         workspace.dispose()
         y.remove_storage(sid)
         y.logout()
 
     def test_sub_unsub(self):
-        y = YAKS()
-        y.login(server_address='127.0.0.1')
+        #self.assertTrue(True)
+        y = YAKS.login(server_address='127.0.0.1')
         properties = {'is.yaks.storage.selector': Selector('/myyaks')}
-        stid = y.create_storage(123, properties)
+        stid = y.create_storage('123', properties)
         workspace = y.workspace(Path('/myyaks'))
         local_var = mvar.MVar()
 
@@ -89,7 +114,8 @@ class APITest(unittest.TestCase):
                                'value': Value('123')}])
             local_var.put(kvs)
 
-        sid = workspace.subscribe(Selector('/myyaks/key1'), cb)
+        sid = workspace.subscribe(
+            Selector('/myyaks/key1'), cb, paths_as_strings=False)
         workspace.put(Path('/myyaks/key1'), Value('123'))
         self.assertEqual(local_var.get(),
                          [{'key': Path('/myyaks/key1'),
@@ -101,22 +127,64 @@ class APITest(unittest.TestCase):
 
     def test_eval(self):
         #self.assertTrue(True)
-        y = YAKS()
-        y.login(server_address='127.0.0.1')
+        y = YAKS.login(server_address='127.0.0.1')
         properties = {'is.yaks.storage.selector': Selector('/myyaks')}
-        stid = y.create_storage(123, properties)
+        stid = y.create_storage('123', properties)
+        workspace = y.workspace(Path('/myyaks'))
+
+        def cb(path, hello):
+            return Value('{} World!'.format(hello))
+
+        workspace.eval(Path('/myyaks/key1'), cb, paths_as_strings=False)
+        kvs = workspace.get(
+            Selector('/myyaks/key1?[hello=mondo]'), paths_as_strings=False)
+        self.assertEqual(kvs,
+                         [{'key': Path('/myyaks/key1'),
+                              'value': Value('mondo World!')}])
+        workspace.remove(Path('/myyaks/key1'))
+        workspace.dispose()
+        y.remove_storage(stid)
+        y.logout()
+
+        def test_sub_unsub_strings(self):
+            y = YAKS.login(server_address='127.0.0.1')
+            properties = {'is.yaks.storage.selector': Selector('/myyaks')}
+            stid = y.create_storage('123', properties)
+            workspace = y.workspace(Path('/myyaks'))
+            local_var = mvar.MVar()
+
+            def cb(kvs):
+                self.assertEqual(kvs,
+                                 [{'key': '/myyaks/key1',
+                                   'value': Value('123')}])
+                local_var.put(kvs)
+            sid = workspace.subscribe(
+                Selector('/myyaks/key1'), cb)
+            workspace.put('/myyaks/key1', Value('123'))
+            self.assertEqual(local_var.get(),
+                             [{'key': '/myyaks/key1',
+                                'value': Value('123')}])
+            self.assertTrue(workspace.unsubscribe(sid))
+            workspace.dispose()
+            y.remove_storage(stid)
+            y.logout()
+
+    def test_eval_string(self):
+        #self.assertTrue(True)
+        y = YAKS.login(server_address='127.0.0.1')
+        properties = {'is.yaks.storage.selector': Selector('/myyaks')}
+        stid = y.create_storage('123', properties)
         workspace = y.workspace(Path('/myyaks'))
 
         def cb(path, hello):
             return Value('{} World!'.format(hello))
 
         workspace.eval(Path('/myyaks/key1'), cb)
-        kvs = workspace.get(
-            Selector('/myyaks/key1?[hello=mondo]'))
+        kvs = workspace.get('/myyaks/key1?[hello=mondo]')
         self.assertEqual(kvs,
-                         [{'key': Path('/myyaks/key1'),
+                         [{'key': '/myyaks/key1',
                               'value': Value('mondo World!')}])
-        workspace.remove(Path('/myyaks/key1'))
+        workspace.remove('/myyaks/key1')
         workspace.dispose()
         y.remove_storage(stid)
         y.logout()

--- a/yaks/tests/test_api.py
+++ b/yaks/tests/test_api.py
@@ -146,28 +146,27 @@ class APITest(unittest.TestCase):
         y.remove_storage(stid)
         y.logout()
 
-        def test_sub_unsub_strings(self):
-            y = YAKS.login(server_address='127.0.0.1')
-            properties = {'is.yaks.storage.selector': Selector('/myyaks')}
-            stid = y.create_storage('123', properties)
-            workspace = y.workspace(Path('/myyaks'))
-            local_var = mvar.MVar()
+    def test_sub_unsub_strings(self):
+        y = YAKS.login(server_address='127.0.0.1')
+        properties = {'is.yaks.storage.selector': Selector('/myyaks')}
+        stid = y.create_storage('123', properties)
+        workspace = y.workspace(Path('/myyaks'))
+        local_var = mvar.MVar()
 
-            def cb(kvs):
-                self.assertEqual(kvs,
-                                 [{'key': '/myyaks/key1',
-                                   'value': Value('123')}])
-                local_var.put(kvs)
-            sid = workspace.subscribe(
-                Selector('/myyaks/key1'), cb)
-            workspace.put('/myyaks/key1', Value('123'))
-            self.assertEqual(local_var.get(),
+        def cb(kvs):
+            self.assertEqual(kvs,
                              [{'key': '/myyaks/key1',
-                                'value': Value('123')}])
-            self.assertTrue(workspace.unsubscribe(sid))
-            workspace.dispose()
-            y.remove_storage(stid)
-            y.logout()
+                               'value': Value('123')}])
+            local_var.put(kvs)
+        sid = workspace.subscribe('/myyaks/key1', cb)
+        workspace.put('/myyaks/key1', Value('123'))
+        self.assertEqual(local_var.get(),
+                         [{'key': '/myyaks/key1',
+                            'value': Value('123')}])
+        self.assertTrue(workspace.unsubscribe(sid))
+        workspace.dispose()
+        y.remove_storage(stid)
+        y.logout()
 
     def test_eval_string(self):
         #self.assertTrue(True)
@@ -177,9 +176,10 @@ class APITest(unittest.TestCase):
         workspace = y.workspace(Path('/myyaks'))
 
         def cb(path, hello):
+            self.assertTrue(isinstance(path, str))
             return Value('{} World!'.format(hello))
 
-        workspace.eval(Path('/myyaks/key1'), cb)
+        workspace.eval('/myyaks/key1', cb)
         kvs = workspace.get('/myyaks/key1?[hello=mondo]')
         self.assertEqual(kvs,
                          [{'key': '/myyaks/key1',

--- a/yaks/tests/test_messages.py
+++ b/yaks/tests/test_messages.py
@@ -151,15 +151,6 @@ class MessagesTests(unittest.TestCase):
         self.assertEqual(msg1.flags, msg2.flags)
         self.assertEqual(msg2.get_values(), v1)
 
-    def test_set_encoding_protobuf(self):
-        v1 = [
-            {'key': Path('/hello'),
-                         'value': Value('world', encoding=PROTOBUF)},
-        ]
-        msg1 = messages.Message()
-        msg1.message_code = messages.VALUES
-        self.assertRaises(NotImplementedError, msg1.add_values, v1)
-
     def test_value_encoding_invalid(self):
         v1 = [
             {'key': Path('/hello'), 'value': Value('world', encoding=INVALID)},

--- a/yaks/tests/test_selector.py
+++ b/yaks/tests/test_selector.py
@@ -18,7 +18,7 @@ from yaks import Path
 from yaks.exceptions import *
 
 
-class PathTests(unittest.TestCase):
+class SelectorTests(unittest.TestCase):
 
     def test_selector_simple(self):
         s = Selector('/this/is/a/selector')

--- a/yaks/tests/test_value.py
+++ b/yaks/tests/test_value.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2018 ADLINK Technology Inc.
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors: Gabriele Baldoni, ADLINK Technology Inc. - Tests
+
+import unittest
+from yaks import Value
+from yaks.encoding import *
+
+
+class ValueTests(unittest.TestCase):
+
+    def test_raw_value(self):
+        v = Value('test raw value')
+        self.assertEqual('test raw value', v.get_value())
+        self.assertEqual(RAW, v.encoding)
+
+    def test_string_value(self):
+        v = Value('test string value', encoding=STRING)
+        self.assertEqual('test string value', v.get_value())
+        self.assertEqual(STRING, v.encoding)
+
+    def test_json_value(self):
+        d = {
+            'this': 'is',
+            'a': 'json value'
+        }
+        v = Value(d, encoding=JSON)
+        self.assertEqual(d, v.get_value())
+        self.assertEqual(JSON, v.encoding)
+
+    def test_sql_value(self):
+        sql = ['this', 'is', 'a', 'sql', 'value']
+        v = Value(sql, encoding=SQL)
+        self.assertEqual(sql, v.get_value())
+        self.assertEqual(SQL, v.encoding)
+
+    def test_pb_value(self):
+        pb = 'some protobuf...'
+        self.assertRaises(ValueError, Value, pb, PROTOBUF)
+
+    def test_unsupported_value(self):
+        pb = 'some value...'
+        self.assertRaises(ValueError, Value, pb, 0x100)

--- a/yaks/tests/test_vle_encoder.py
+++ b/yaks/tests/test_vle_encoder.py
@@ -17,7 +17,7 @@ from yaks import encoder
 from random import randint
 
 
-class MessagesTests(unittest.TestCase):
+class VleEncodingTests(unittest.TestCase):
 
     def test_encoding(self):
         e = encoder.VLEEncoder()

--- a/yaks/value.py
+++ b/yaks/value.py
@@ -15,19 +15,27 @@
 import re
 from yaks.exceptions import ValidationError
 from yaks.encoding import *
+import json
 
 
 class Value(object):
     def __init__(self, value, encoding=RAW):
         if encoding > 0xFF:
             raise ValueError('Encoding not supported')
+        if encoding == PROTOBUF:
+            raise ValueError('PROTOBUF Encoding not implemented')
         self.encoding = encoding
-        self.value = value
+        if self.encoding is JSON:
+            self.value = json.dumps(value)
+        else:
+            self.value = value
 
     def get_encoding(self):
         return self.encoding
 
     def get_value(self):
+        if self.encoding is JSON:
+            return json.loads(self.value)
         return self.value
 
     def __eq__(self, second_value):


### PR DESCRIPTION
- **login** become a static method of YAKS and creates the YAKS API ( YAKS.login() returns a **YAKS** object)
- _put_; _update_; _remove_; _eval_; _workspace_ takes **str** or **Path** 
- _get_; _subscribe_ takes  **str** or **Selector**
- _get_; _subscribe_ and _eval_; returns **str** as default for _paths_ the optional parameter _paths_as_string=False allow enable returns of YAKS types 
- storage creation takes an id and a dictionary of properties with at least the property _is.yaks.storage.selector_ set with a valid **str**  or **Selector**